### PR TITLE
Remove warnings on task definition creation

### DIFF
--- a/aws/build-task-definition/build-task-definition.sh
+++ b/aws/build-task-definition/build-task-definition.sh
@@ -5,7 +5,7 @@ get_task_definition() {
   task_name=$1
 
   # Thoses keys are returned by the Amazon ECS DescribeTaskDefinition, but are not valid fields when registering a new task definition
-  keys_to_omit=".compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .status"
+  keys_to_omit=".compatibilities, .taskDefinitionArn, .requiresAttributes, .revision, .status, .registeredBy, .registeredAt"
 
   returned_task_definition=$(aws ecs describe-task-definition --task-definition "${task_name}" | jq .taskDefinition | jq "del($keys_to_omit)")
   if [ -z "${returned_task_definition}" ]; then


### PR DESCRIPTION
The goal of this PR is to remove `registeredBy` and `registeredAt` properties when creating task definitions. 
These two properties are returned from the AWS ECS DescribeTaskDefinition command but are not valid fields for creation. 

The following screenshot shows the warnings:
![image](https://user-images.githubusercontent.com/39057274/106159355-b06bcf00-6152-11eb-9391-fbffafe2ec79.png)
